### PR TITLE
Add Identity and EF Core setup in Program and DataContext

### DIFF
--- a/Presentation/Data/Contexts/DataContext.cs
+++ b/Presentation/Data/Contexts/DataContext.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Presentation.Data.Contexts;
+
+public class DataContext(DbContextOptions<DataContext> options) : IdentityDbContext<IdentityUser>(options)
+{
+}

--- a/Presentation/Program.cs
+++ b/Presentation/Program.cs
@@ -1,7 +1,17 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Presentation.Data.Contexts;
 using Presentation.Services;
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddGrpc();
 
+builder.Services.AddDbContext<DataContext>(x => x.UseSqlServer(builder.Configuration.GetConnectionString("AuthenticationServer")));
+builder.Services.AddIdentity<IdentityUser, IdentityRole>(option =>
+{
+    option.SignIn.RequireConfirmedEmail = true;
+    option.User.RequireUniqueEmail = true;
+    option.Password.RequiredLength = 8;
+}).AddEntityFrameworkStores<DataContext>().AddDefaultTokenProviders();
 
 
 var app = builder.Build();


### PR DESCRIPTION
Updated Program.cs to configure ASP.NET Core Identity and Entity Framework Core with a new DataContext using SQL Server. Added identity options for user management and mapped a gRPC service.

Modified DataContext.cs to inherit from IdentityDbContext, enabling identity-related data handling.