### PR TITLE
Add EmailConfirmed flag to new IdentityUser creation

### DIFF
--- a/Presentation/Services/AccountService.cs
+++ b/Presentation/Services/AccountService.cs
@@ -14,6 +14,7 @@ public class AccountService(UserManager<IdentityUser> userManager) : AccountGrpc
         {
             UserName = request.Email,
             Email = request.Email,
+            EmailConfirmed = true
         };
 
         var result = await _userManager.CreateAsync(user, request.Password);


### PR DESCRIPTION
This change sets the EmailConfirmed property to true when creating a new IdentityUser instance in the AccountService class. This ensures that the user's email is marked as confirmed upon account creation, enhancing user management and security.