### PR TITLE
Add ChangeUserRole RPC and implementation

### DIFF
--- a/Presentation/Protos/account.proto
+++ b/Presentation/Protos/account.proto
@@ -10,6 +10,7 @@ service AccountGrpcService {
 	rpc GetAccount (GetAccountRequest) returns (GetAccountReply);
 	rpc UpdatePhoneNumber (UpdatePhoneNumberRequest) returns (UpdatePhoneNumberReply);
 	rpc DeleteAccountById (DeleteAccountByIdRequest) returns (DeleteAccountByIdReply);
+	rpc ChangeUserRole (ChangeUserRoleRequest) returns (ChangeUserRoleReply); 
 
 	rpc ConfirmAccount (ConfirmAccountRequest) returns (ConfirmAccountReply);
 	rpc ConfirmEmailChange (ConfirmEmailChangeRequest) returns (ConfirmEmailChangeReply);
@@ -85,6 +86,16 @@ message DeleteAccountByIdRequest {
 message DeleteAccountByIdReply {
 	bool succeeded = 1;
 	string message = 2;
+}
+
+message ChangeUserRoleRequest {
+    string user_id = 1;
+    string new_role = 2;
+}
+
+message ChangeUserRoleReply {
+    bool succeeded = 1;
+    string message = 2;
 }
 
 message ConfirmAccountRequest {


### PR DESCRIPTION
Introduced a new RPC method `ChangeUserRole` in `AccountGrpcService` to facilitate changing a user's role. Added corresponding request and reply message types, `ChangeUserRoleRequest` and `ChangeUserRoleReply`, with necessary fields. Implemented the method in `AccountService.cs`, which handles role validation, user retrieval, role removal, and addition, returning success or failure messages.